### PR TITLE
Add checks for 40h and series.

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,14 @@ module.exports = function (id) {
     if (device.type != 'grid') {
       return;
     }
-    if (device.id.match(/m\d+/)) {
+    // check if 40h or series
+    if (device.id.match(/m40h\d+/) ||
+        device.id.match(/m64\-\d+/) ||
+        device.id.match(/m128\-\d+/) ||
+        device.id.match(/m256\-\d+/)) {
+      grid.varibright = false;
+    }
+    else if (device.id.match(/m\d+/)) {
       grid.varibright = true;
     }
     activeDevice = device;


### PR DESCRIPTION
Found that my old 64 wasn't getting recognized as non-varibright properly. Added checks for series and 40h per tehn's comments [here](http://monome.org/community/discussion/18459/grid-versions#Item_1).
