### PR TITLE
Removing UVRun, which seemed to block forver for me.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var serialosc = require('serialosc');
-var uvrun = require('uvrun-12');
 
 var activeDevice;
 
@@ -75,8 +74,5 @@ module.exports = function (id) {
     });
     device.start();
   });
-  while (!grid.ready) {
-    uvrun.runOnce();
-  }
   return grid;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monome-grid",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "simple monome grid library",
   "main": "index.js",
   "scripts": {
@@ -19,13 +19,16 @@
     "name": "Tom Dinchak",
     "email": "dinchak@gmail.com"
   },
+  "contributors": [{
+    "name": "Tom Armitage",
+    "email": "tom@infovore.org"
+  }],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/dinchak/node-monome-grid/issues"
   },
   "homepage": "https://github.com/dinchak/node-monome-grid",
   "dependencies": {
-    "serialosc": "0.0.4",
-    "uvrun-12": "^0.1.3"
+    "serialosc": "0.0.4"
   }
 }


### PR DESCRIPTION
What's the purpose of blocking with UVRun until the grid is 'ready'?

I ask because on my setup - OSX 10.10, Node 8.9.1 - the script just blocks forever; the grid is never registered as ready. Just tearing out the uvrun code makes everything work correctly. So that's what I've done here.